### PR TITLE
Eden/copilot

### DIFF
--- a/api/langchain/agent.py
+++ b/api/langchain/agent.py
@@ -94,7 +94,7 @@ class Agent:
             if self._llm_model is not None:
                 self._llm = self._llm_model
             else:
-                self._llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+                self._llm = ChatOpenAI(model="gpt-5-nano", temperature=0)
         return self._llm
 
     def explain(


### PR DESCRIPTION
This pull request introduces significant improvements to the agent streaming API and enhances session management and agent configuration. The main change is the addition of a server-sent events (SSE) endpoint for streaming updates from the LangGraph agent, enabling real-time feedback during agent execution. Other important updates include improved session handling, agent configuration, and memory synchronization.

**Agent Streaming and API Enhancements:**

* Added a new `/api/agent/explore` GET endpoint in `index.py` that streams agent updates using server-sent events (SSE), providing real-time feedback for thoughts, tool calls, and results. The previous POST endpoint is commented out.
* Implemented event streaming logic using a queue and threading to handle agent events, normalizing payloads for SSE and ensuring compatibility with older agent response formats.

**Session and Agent Configuration Improvements:**

* Updated agent initialization in `agent.py` to accept and use a `session_id`, ensuring thread IDs and memory are session-qualified. The agent's LLM model is now set to `gpt-5-nano` by default. [[1]](diffhunk://#diff-2c5d70a8140d3139f16e7324aeb1d819bcecaf0828b9fee808901a7ba7b00ff2R57) [[2]](diffhunk://#diff-2c5d70a8140d3139f16e7324aeb1d819bcecaf0828b9fee808901a7ba7b00ff2L69-R70) [[3]](diffhunk://#diff-2c5d70a8140d3139f16e7324aeb1d819bcecaf0828b9fee808901a7ba7b00ff2R91-R100) [[4]](diffhunk://#diff-2c5d70a8140d3139f16e7324aeb1d819bcecaf0828b9fee808901a7ba7b00ff2L577-R580)
* Enhanced the `load_property` call to pass the session ID for context-aware property loading.

**Memory Synchronization:**

* Improved memory retriever session switching to synchronize namespace counters with persisted collections, preventing incorrect empty memory reports on fresh loads.

**LangGraph Agent Node Improvements:**

* Refactored agent node creation in `langgraph.py` to include node names, improving traceability and event streaming. The event callback mechanism (`event_cb`) was introduced for streaming agent updates. [[1]](diffhunk://#diff-49392c820c792e269a6147add4beb4a491a45c40927112201b5499d4e8feeee6R158-R159) [[2]](diffhunk://#diff-49392c820c792e269a6147add4beb4a491a45c40927112201b5499d4e8feeee6R279) [[3]](diffhunk://#diff-49392c820c792e269a6147add4beb4a491a45c40927112201b5499d4e8feeee6R292) [[4]](diffhunk://#diff-49392c820c792e269a6147add4beb4a491a45c40927112201b5499d4e8feeee6R306) [[5]](diffhunk://#diff-49392c820c792e269a6147add4beb4a491a45c40927112201b5499d4e8feeee6R317) [[6]](diffhunk://#diff-49392c820c792e269a6147add4beb4a491a45c40927112201b5499d4e8feeee6L339-R350) [[7]](diffhunk://#diff-49392c820c792e269a6147add4beb4a491a45c40927112201b5499d4e8feeee6L364-R380) [[8]](diffhunk://#diff-49392c820c792e269a6147add4beb4a491a45c40927112201b5499d4e8feeee6R647) [[9]](diffhunk://#diff-49392c820c792e269a6147add4beb4a491a45c40927112201b5499d4e8feeee6L650-R671)